### PR TITLE
cleanup: drop commented out clang shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -7,9 +7,6 @@
   withDebug ? false,
   withGui ? false,
 }:
-#pkgs.clangStdenv.mkDerivation {
-#  name = "libcxxStdenv";
-# clang_13
 let
   inherit (pkgs.lib) optionals strings;
   binDirs =


### PR DESCRIPTION
Not needed anymore since #7.